### PR TITLE
add recipes endpoint to get multiple recipes

### DIFF
--- a/db/database.py
+++ b/db/database.py
@@ -1,6 +1,8 @@
 import sqlite3
 import json
-from typing import Union
+from typing import Union, List
+
+from models.recipe import RecipeResponse
 
 DB: str = "db/recipes.db"
 
@@ -44,6 +46,26 @@ def fetch_recipe_by_id(id: int) -> Union[dict, None]:
             }
         else:
             return None
+
+
+def fetch_recipes(limit: int, offset: int) -> Union[List[dict], None]:
+    """
+    Returns multiple recipes dict (RecipesResponse)
+    """
+    recipes = []
+    with sqlite3.connect(DB, check_same_thread=False) as conn:
+        cursor = conn.cursor()
+        for data in cursor.execute(f"SELECT * FROM items LIMIT {limit} OFFSET {offset}"):
+            recipes.append({
+                "id": data[0],
+                "name": normalize_string(data[1]),
+                "total_duration": data[2],
+                "ingredients": json.loads(
+                    data[3].replace("'", '"')
+                ),  # convert string list to python list
+                "directions": data[4],
+            })
+    return recipes
 
 
 def normalize_string(s: str) -> str:

--- a/main.py
+++ b/main.py
@@ -2,8 +2,8 @@ import uvicorn
 from fastapi import FastAPI
 from typing import Union
 
-from db.database import fetch_random_recipe, fetch_recipe_by_id
-from models.recipe import Recipe, RecipeResponse
+from db.database import fetch_random_recipe, fetch_recipe_by_id, fetch_recipes
+from models.recipe import Recipe, RecipeResponse, RecipesResponse
 from models.error import NotFoundResponse
 
 
@@ -11,7 +11,7 @@ app = FastAPI()
 
 
 @app.get("/", response_model=RecipeResponse, responses={200: {"model": RecipeResponse}})
-def get_recipes() -> dict:
+def get_random_recipe() -> RecipeResponse:
     """
     This function returns a random recipe from the database.
     ---
@@ -39,6 +39,26 @@ def get_recipe_by_id(id: int) -> dict:
     recipe: Recipe = fetch_recipe_by_id(id)
     if recipe is not None:
         return {"status": 200, "recipe": recipe}
+    return {"status": 404, "message": "recipe not found"}
+
+
+@app.get("/recipes/",
+    response_model=Union[RecipesResponse, NotFoundResponse],
+    responses={200: {"model": RecipesResponse}, 404: {"model": NotFoundResponse}},
+)
+def get_recipes(limit:int = 5, offset:int = 0) -> RecipesResponse:
+    """
+    This function returns multiple recipes from the database.
+    ---
+    Args:
+        limit (int): numbers of recipes to be returned.
+        offset (int): parameter to skip certain rows.
+    Returns:
+        RecipesResponse: A dictionary containing status code and multiple recipes. 
+    """
+    recipes = fetch_recipes(limit, offset)
+    if len(recipes):
+        return {"status": 200, "results": recipes}
     return {"status": 404, "message": "recipe not found"}
 
 

--- a/models/recipe.py
+++ b/models/recipe.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from typing import List
 
 
 class Recipe(BaseModel):
@@ -23,3 +24,8 @@ class Recipe(BaseModel):
 class RecipeResponse(BaseModel):
     status: int
     recipe: Recipe
+
+
+class RecipesResponse(BaseModel):
+    status: int
+    results: List[Recipe]


### PR DESCRIPTION
Hi!
I gave it a shot to create a endpoint to offer more flexible response.

**Changes:**
- Add ```/recipes/``` endpoint to get multiple recipes.
- Query parameter (limit, offset) allows to vary how many recipes to be returned and skip rows in DB.

**Sample request:**
```python
import requests
r = requests.get("http://localhost:8000/recipes/?limit=2&offset=5")
data = r.json()
```

**Sample response:**
```json
{
    "status": 200,
    "results": [
        {
            "id": 14,
            "name": "Pumpernickel Bread II Recipe",
            "total_duration": 60,
            "ingredients": [
                "brown sugar",
                "cocoa powder",
                "salt",
                "cornmeal",
                "milk",
                "flour",
                "molasses",
                "bread",
                "yeast",
                "vegetable oil"
            ],
            "directions": "Mix well bread flour, rye flour, cornmeal, salt, yeast, cocoa, and brown sugar. Add milk, oil, and molasses. Mix thoroughly. When mixed well enough that the dough holds together, knead by hand 15-20 minutes.Cover, let rise in bowl 30 minutes. Punch down, form, and place into 9 1/2x5 inch pan. Cover with damp cloth and let rise about 1 hour.Bake in preheated 375 degree F (190 degrees C) oven 25 to 30 minutes, covering top with aluminum foil last 10 minutes."
        },
        {
            "id": 18,
            "name": "Light Oat Bread Recipe",
            "total_duration": 180,
            "ingredients": [
                "brown sugar",
                "water",
                "salt",
                "flour",
                "margarine",
                "oat",
                "yeast"
            ],
            "directions": "Add ingredients to bread machine pan in order recommended by your manufacturer. Use regular light setting."
        }
    ]
}
```